### PR TITLE
:sparkles: Feat: 적립유무 확인 화면 구현

### DIFF
--- a/src/pages/Package.jsx
+++ b/src/pages/Package.jsx
@@ -31,6 +31,8 @@ function PackagePage() {
     } catch (err) {
       console.error(err);
     }
+
+    navigate("/order/point");
   }
 
   return (

--- a/src/pages/PointCheck.jsx
+++ b/src/pages/PointCheck.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import BackButton from "../components/BackButton";
+import { saveOrderPoint } from "../utils/orderSpec";
+import {
+  Page,
+  BottomAccentBar,
+  Title,
+  CardGrid,
+  Card,
+  CardLabel,
+  IconCenter,
+  CrossIcon,
+  CircleIcon,
+} from "./PointCheck.styles";
+
+function PointCheckPage() {
+  const navigate = useNavigate();
+
+  function handleBack() {
+    navigate(-1);
+  }
+
+  function handleSelect(save) {
+    try {
+      saveOrderPoint({ type: !!save });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <Page>
+      <BackButton onClick={handleBack} />
+      <Title>주문 내역을 기억해드릴까요?</Title>
+      <CardGrid>
+        <Card type="button" onClick={() => handleSelect(false)}>
+          <IconCenter>
+            <CrossIcon />
+          </IconCenter>
+          <CardLabel>아니요</CardLabel>
+        </Card>
+        <Card type="button" onClick={() => handleSelect(true)}>
+          <IconCenter>
+            <CircleIcon />
+          </IconCenter>
+          <CardLabel>좋아요</CardLabel>
+        </Card>
+      </CardGrid>
+      <BottomAccentBar aria-hidden="true" />
+    </Page>
+  );
+}
+
+export default PointCheckPage;

--- a/src/pages/PointCheck.jsx
+++ b/src/pages/PointCheck.jsx
@@ -23,7 +23,7 @@ function PointCheckPage() {
 
   function handleSelect(save) {
     try {
-      saveOrderPoint({ type: !!save });
+      saveOrderPoint({ enabled: !!save });
     } catch (err) {
       console.error(err);
     }

--- a/src/pages/PointCheck.styles.js
+++ b/src/pages/PointCheck.styles.js
@@ -61,6 +61,11 @@ export const Card = styled.button`
   &:focus {
     outline: none;
   }
+  &:focus-visible {
+    outline: 0.25rem solid #223770;
+    outline-offset: 0.25rem;
+    border-radius: 1.875rem;
+  }
 `;
 
 export const CardLabel = styled.div`

--- a/src/pages/PointCheck.styles.js
+++ b/src/pages/PointCheck.styles.js
@@ -1,0 +1,124 @@
+import styled from "styled-components";
+
+export const Page = styled.div`
+  position: relative;
+  width: 1440px;
+  height: 1024px;
+  margin: 0 auto;
+  background: #f2f6fb;
+  overflow: hidden;
+`;
+
+export const BottomAccentBar = styled.div`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 14.3125rem;
+  background: #223770;
+  border-top-left-radius: 1.875rem;
+  border-top-right-radius: 1.875rem;
+  z-index: 0;
+`;
+
+export const Title = styled.h1`
+  position: absolute;
+  left: 23.31rem;
+  top: 6rem;
+  text-align: center;
+  font-family: "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 4rem;
+  line-height: normal;
+  letter-spacing: -0.06rem;
+  color: #000000;
+`;
+
+export const CardGrid = styled.div`
+  position: absolute;
+  left: 50%;
+  top: 18.125rem;
+  transform: translateX(-50%);
+  display: grid;
+  grid-template-columns: 32.125rem 32.125rem;
+  gap: 2.75rem;
+  z-index: 1;
+`;
+
+export const Card = styled.button`
+  width: 32.125rem;
+  height: 37.5rem;
+  background: #ffffff;
+  box-shadow: 0.1875rem 0.4375rem 0.625rem rgba(0, 0, 0, 0.25);
+  border-radius: 1.875rem;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  padding: 0;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+export const CardLabel = styled.div`
+  position: absolute;
+  bottom: 6.88rem;
+  width: 100%;
+  font-family: "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
+  font-weight: 700;
+  font-size: 4.375rem;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: -0.06563rem;
+  color: #272727;
+`;
+
+export const IconCenter = styled.div`
+  position: absolute;
+  width: 17.5rem;
+  height: 17.5rem;
+  top: 8.6rem;
+  left: 10.14rem;
+`;
+
+export const CrossIcon = styled.div`
+  position: relative;
+  width: 17.5rem;
+  height: 17.5rem;
+
+  top: -3rem;
+  left: -2.85rem;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 13.88875rem;
+    height: 1.66688rem;
+    background: #223770;
+    border-radius: 1.875rem;
+    transform-origin: center;
+  }
+
+  &::before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+
+  &::after {
+    transform: translate(-50%, -50%) rotate(135deg);
+  }
+`;
+
+export const CircleIcon = styled.div`
+  box-sizing: border-box;
+  width: 11.62rem;
+  height: 11.55rem;
+  border: 1.25rem solid #d22a2a;
+  border-radius: 50%;
+`;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -10,6 +10,7 @@ import VoiceRecognize from "../pages/VoiceRecognize";
 import PhoneOrder from "../pages/PhoneOrder";
 import VoiceCart from "../pages/VoiceCart";
 import PackagePage from "../pages/Package";
+import PointCheckPage from "../pages/PointCheck";
 // 추후 추가될 페이지들을 위한 임포트 (현재는 주석 처리)
 // import NotFound from "./pages/NotFound";
 
@@ -23,6 +24,7 @@ export default function AppRouter() {
         <Route path="/order/touch" element={<TouchOrder />} />
         <Route path="/order/touch/cart" element={<TouchCart />} />
         <Route path="/order/package" element={<PackagePage />} />
+        <Route path="/order/point" element={<PointCheckPage />} />
         <Route path="/order/voice" element={<VoiceOrder />} />
         <Route path="/order/voice/one-two" element={<VoiceOneTwo />} />
         <Route path="/order/voice/recognize" element={<VoiceRecognize />} />

--- a/src/utils/orderSpec.js
+++ b/src/utils/orderSpec.js
@@ -4,6 +4,7 @@ function getDefaultOrderSpec() {
   return {
     cart: [],
     package: {},
+    point: {},
   };
 }
 
@@ -21,14 +22,15 @@ export function loadOrderSpec() {
     if (raw) {
       const parsed = safeParse(raw);
       if (parsed && typeof parsed === "object") {
-        const pkg = parsed?.package ?? parsed?.meta ?? {};
+        const pkg = parsed?.package ?? {};
+        const point = parsed?.point ?? {};
         const cartRaw = parsed?.cart;
         if (Array.isArray(cartRaw)) {
-          return { cart: cartRaw, package: pkg };
+          return { cart: cartRaw, package: pkg, point };
         }
         const legacyItemsById = cartRaw?.itemsById ?? {};
         const migratedArray = Object.values(legacyItemsById);
-        return { cart: migratedArray, package: pkg };
+        return { cart: migratedArray, package: pkg, point };
       }
     }
     return getDefaultOrderSpec();
@@ -61,6 +63,7 @@ export function saveCartItems(cartOrMap) {
   const next = {
     cart: itemsArray,
     package: current.package ?? {},
+    point: current.point ?? {},
   };
   saveOrderSpec(next);
 }
@@ -70,6 +73,17 @@ export function saveOrderPackage(packagePartial) {
   const next = {
     cart: Array.isArray(current.cart) ? current.cart : [],
     package: { ...(current.package ?? {}), ...(packagePartial ?? {}) },
+    point: current.point ?? {},
+  };
+  saveOrderSpec(next);
+}
+
+export function saveOrderPoint(pointPartial) {
+  const current = loadOrderSpec();
+  const next = {
+    cart: Array.isArray(current.cart) ? current.cart : [],
+    package: current.package ?? {},
+    point: { ...(current.point ?? {}), ...(pointPartial ?? {}) },
   };
   saveOrderSpec(next);
 }


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #66 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 적립유무 확인 화면 구현


## ✔️ 체크 리스트
- [✔️] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [✔️] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ‘주문 기억하기’ 확인 페이지 추가: 두 가지 카드 선택(아니요/좋아요), 선택값 저장 및 뒤로가기 지원
  - 주문 흐름 업데이트: 패키지 단계 이후 확인 페이지로 자동 이동
  - 주문 정보에 포인트 섹션을 포함해 선택 상태가 이후 단계에서도 유지
- Style
  - 새 확인 페이지용 레이아웃, 카드, 라벨, 아이콘 등 시각 요소 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->